### PR TITLE
Allow `Constraint` to convert `Int`s into `Float64` in the bounds

### DIFF
--- a/docs/src/metabolic-modeling.jl
+++ b/docs/src/metabolic-modeling.jl
@@ -346,7 +346,7 @@ Dict(k => v.fluxes.R_BIOMASS_Ecoli_core_w_GAM for (k, v) in result.community)
 # both dot-access and array-index syntax.
 
 # You can thus, e.g., set a single bound:
-c.exchanges.oxygen.bound = (-20, 20)
+c.exchanges.oxygen.bound = (-20.0, 20.0)
 
 # ...or rebuild a whole constraint:
 c.exchanges.biomass = C.Constraint(c.exchanges.biomass.value, (-20, 20))

--- a/docs/src/metabolic-modeling.jl
+++ b/docs/src/metabolic-modeling.jl
@@ -280,8 +280,8 @@ C.constraint_values(c.objective, optimal_variable_assignment)
 # organisms:
 c =
     :community^(
-        :species1^(c * :handicap^C.Constraint(c.fluxes.R_PFK.value, 0.0)) +
-        :species2^(c * :handicap^C.Constraint(c.fluxes.R_ACALD.value, 0.0))
+        :species1^(c * :handicap^C.Constraint(c.fluxes.R_PFK.value, 0)) +
+        :species2^(c * :handicap^C.Constraint(c.fluxes.R_ACALD.value, 0))
     )
 
 # We can create additional variables that represent total community intake of
@@ -346,10 +346,10 @@ Dict(k => v.fluxes.R_BIOMASS_Ecoli_core_w_GAM for (k, v) in result.community)
 # both dot-access and array-index syntax.
 
 # You can thus, e.g., set a single bound:
-c.exchanges.oxygen.bound = (-20.0, 20.0)
+c.exchanges.oxygen.bound = (-20.0, 20.0) # typed as Tuple{Float64, Float64}
 
 # ...or rebuild a whole constraint:
-c.exchanges.biomass = C.Constraint(c.exchanges.biomass.value, (-20.0, 20.0))
+c.exchanges.biomass = C.Constraint(c.exchanges.biomass.value, (-20, 20)) # construct automatically converts bounds to floats
 
 # ...or even add new constraints, here using the index syntax for demonstration:
 c[:exchanges][:production_is_zero] = C.Constraint(c.exchanges.biomass.value, 0.0)

--- a/docs/src/metabolic-modeling.jl
+++ b/docs/src/metabolic-modeling.jl
@@ -346,13 +346,13 @@ Dict(k => v.fluxes.R_BIOMASS_Ecoli_core_w_GAM for (k, v) in result.community)
 # both dot-access and array-index syntax.
 
 # You can thus, e.g., set a single bound:
-c.exchanges.oxygen.bound = (-20.0, 20.0) # typed as Tuple{Float64, Float64}
+c.exchanges.oxygen.bound = (-20, 20)
 
 # ...or rebuild a whole constraint:
-c.exchanges.biomass = C.Constraint(c.exchanges.biomass.value, (-20, 20)) # construct automatically converts bounds to floats
+c.exchanges.biomass = C.Constraint(c.exchanges.biomass.value, (-20, 20))
 
 # ...or even add new constraints, here using the index syntax for demonstration:
-c[:exchanges][:production_is_zero] = C.Constraint(c.exchanges.biomass.value, 0.0)
+c[:exchanges][:production_is_zero] = C.Constraint(c.exchanges.biomass.value, 0)
 
 # ...or remove some constraints (this erases the constraint that was added just
 # above):

--- a/docs/src/quadratic-optimization.jl
+++ b/docs/src/quadratic-optimization.jl
@@ -32,7 +32,7 @@ error_val =
 
 # This allows us to naturally express quadratic constraint (e.g., that an error
 # must not be too big); and directly observe the error values in the system.
-system = :vars^system * :error^C.Constraint(value = error_val, bound = (0.0, 100.0))
+system = :vars^system * :error^C.Constraint(error_val, (0, 100))
 
 # (For simplicity, you can also use the `Constraint` constructor to make
 # quadratic constraints out of `QuadraticValue`s -- it will overload properly.)

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -27,9 +27,9 @@ Base.@kwdef mutable struct Constraint{V}
 end
 
 Constraint(v::T, b::Int) where {T<:Value} = Constraint{T}(v, float(b))
-Constraint(v::T, b::Tuple{Int, Int}) where {T<:Value} = Constraint{T}(v, float.(b))
-Constraint(v::T, b::Tuple{Int, Float64}) where {T<:Value} = Constraint{T}(v, float.(b))
-Constraint(v::T, b::Tuple{Float64, Int}) where {T<:Value} = Constraint{T}(v, float.(b))
+Constraint(v::T, b::Tuple{Int,Int}) where {T<:Value} = Constraint{T}(v, float.(b))
+Constraint(v::T, b::Tuple{Int,Float64}) where {T<:Value} = Constraint{T}(v, float.(b))
+Constraint(v::T, b::Tuple{Float64,Int}) where {T<:Value} = Constraint{T}(v, float.(b))
 
 Base.:-(a::Constraint) = -1 * a
 Base.:*(a::Real, b::Constraint) = b * a

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -27,7 +27,8 @@ Base.@kwdef mutable struct Constraint{V}
 end
 
 Constraint(v::T, b::Int) where {T<:Value} = Constraint{T}(v, Float64(b))
-Constraint(v::T, b::Tuple{X,Y}) where {T<:Value,X<:Real,Y<:Real} = Constraint{T}(v, Float64.(b))
+Constraint(v::T, b::Tuple{X,Y}) where {T<:Value,X<:Real,Y<:Real} =
+    Constraint{T}(v, Float64.(b))
 
 Base.:-(a::Constraint) = -1 * a
 Base.:*(a::Real, b::Constraint) = b * a

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -26,9 +26,9 @@ Base.@kwdef mutable struct Constraint{V}
     end
 end
 
-Constraint(v::T, b::Int) where {T<:Value} = Constraint{T}(v, Float64(b))
+Constraint(v::T, b::Int) where {T<:Value} = Constraint(v, Float64(b))
 Constraint(v::T, b::Tuple{X,Y}) where {T<:Value,X<:Real,Y<:Real} =
-    Constraint{T}(v, Float64.(b))
+    Constraint(v, Float64.(b))
 
 Base.:-(a::Constraint) = -1 * a
 Base.:*(a::Real, b::Constraint) = b * a

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -26,10 +26,8 @@ Base.@kwdef mutable struct Constraint{V}
     end
 end
 
-Constraint(v::T, b::Int) where {T<:Value} = Constraint{T}(v, float(b))
-Constraint(v::T, b::Tuple{Int,Int}) where {T<:Value} = Constraint{T}(v, float.(b))
-Constraint(v::T, b::Tuple{Int,Float64}) where {T<:Value} = Constraint{T}(v, float.(b))
-Constraint(v::T, b::Tuple{Float64,Int}) where {T<:Value} = Constraint{T}(v, float.(b))
+Constraint(v::T, b::Int) where {T<:Value} = Constraint{T}(v, Float64(b))
+Constraint(v::T, b::Tuple{X,Y}) where {T<:Value,X<:Real,Y<:Real} = Constraint{T}(v, Float64.(b))
 
 Base.:-(a::Constraint) = -1 * a
 Base.:*(a::Real, b::Constraint) = b * a

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -26,6 +26,11 @@ Base.@kwdef mutable struct Constraint{V}
     end
 end
 
+Constraint(v::T, b::Int) where {T<:Value} = Constraint{T}(v, float(b))
+Constraint(v::T, b::Tuple{Int, Int}) where {T<:Value} = Constraint{T}(v, float.(b))
+Constraint(v::T, b::Tuple{Int, Float64}) where {T<:Value} = Constraint{T}(v, float.(b))
+Constraint(v::T, b::Tuple{Float64, Int}) where {T<:Value} = Constraint{T}(v, float.(b))
+
 Base.:-(a::Constraint) = -1 * a
 Base.:*(a::Real, b::Constraint) = b * a
 Base.:*(a::Constraint, b::Real) = Constraint(


### PR DESCRIPTION
This is just for convenience, because I keep on forgetting to convert it manually... Thoughts? 