### PR TITLE
generalize tree_map to all types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstraintTrees"
 uuid = "5515826b-29c3-47a5-8849-8513ac836620"
 authors = ["The developers of ConstraintTrees.jl"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -95,8 +95,9 @@ end
 $(TYPEDSIGNATURES)
 
 Run a function over everything in the tree. The resulting tree will contain
-elements of type `output_type`. (This needs to be specified explicitly, because
-the typesystem generally cannot guess the type correctly.)
+elements of type specified by the 3rd argument. (This needs to be specified
+explicitly, because the typesystem generally cannot guess the universal type
+correctly.)
 """
 tree_map(x::Tree, f, ::Type{T}) where {T} = Tree{T}(k => tree_map(v, f, T) for (k, v) in x)
 

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -98,6 +98,6 @@ Run a function over everything in the tree. The resulting tree will contain
 elements of type `output_type`. (This needs to be specified explicitly, because
 the typesystem generally cannot guess the type correctly.)
 """
-tree_map(x::Tree, f, output_type::DataType) = Tree{output_type}(
-    k => (v isa Tree ? tree_map(v, f, output_type) : f(v)) for (k, v) in x
-)
+tree_map(x::Tree, f, ::Type{T}) where {T} = Tree{T}(k => tree_map(v, f, T) for (k, v) in x)
+
+tree_map(x, f, ::Type) = f(x)


### PR DESCRIPTION
(Who'd say UnionAll isn't a DataType. Also kill one ugly if-is-a.)

Bumps 0.8.1 (more of a bugfix than a feature).