### PR TITLE
`to_repr` and `from_repr`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstraintTrees"
 uuid = "5515826b-29c3-47a5-8849-8513ac836620"
 authors = ["The developers of ConstraintTrees.jl"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/ConstraintTrees.jl
+++ b/src/ConstraintTrees.jl
@@ -66,5 +66,6 @@ include("constraint.jl")
 include("tree.jl")
 include("constraint_tree.jl")
 include("pretty.jl")
+include("repr.jl")
 
 end # module ConstraintTrees

--- a/src/repr.jl
+++ b/src/repr.jl
@@ -21,7 +21,8 @@ Represent a [`Tree`](@ref) using base Julia structures.
 Useful for saving trees in JSON, YAML and other formats that can work with
 `Dict`s and `Vector`s.
 """
-to_repr(x::Tree{T}) where {T} = Dict(repr_label(Tree{T}) => Dict(String(k) => to_repr(v) for (k,v)=x))
+to_repr(x::Tree{T}) where {T} =
+    Dict(repr_label(Tree{T}) => Dict(String(k) => to_repr(v) for (k, v) in x))
 
 repr_label(::Type{Tree}) = "tree"
 
@@ -33,4 +34,5 @@ Create a [`Tree`](@ref) from base Julia structures.
 Useful for loading trees from JSON, YAML and other formats that can work with
 `Dict`s and `Vector`s.
 """
-from_repr(::Type{Tree{T}}, x::AbstractDict) where {T<:Tree} = Tree{T}(Symbol(k) => from_repr(v) for (k,v)=x)
+from_repr(::Type{Tree{T}}, x::AbstractDict) where {T<:Tree} =
+    Tree{T}(Symbol(k) => from_repr(v) for (k, v) in x)

--- a/src/repr.jl
+++ b/src/repr.jl
@@ -1,0 +1,36 @@
+
+# Copyright (c) 2024, University of Luxembourg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+$(TYPEDSIGNATURES)
+
+Represent a [`Tree`](@ref) using base Julia structures.
+
+Useful for saving trees in JSON, YAML and other formats that can work with
+`Dict`s and `Vector`s.
+"""
+to_repr(x::Tree{T}) where {T} = Dict(repr_label(Tree{T}) => Dict(String(k) => to_repr(v) for (k,v)=x))
+
+repr_label(::Type{Tree}) = "tree"
+
+"""
+$(TYPEDSIGNATURES)
+
+Create a [`Tree`](@ref) from base Julia structures.
+
+Useful for loading trees from JSON, YAML and other formats that can work with
+`Dict`s and `Vector`s.
+"""
+from_repr(::Type{Tree{T}}, x::AbstractDict) where {T<:Tree} = Tree{T}(Symbol(k) => from_repr(v) for (k,v)=x)


### PR DESCRIPTION
While working on COBREXA I noticed that it would be super useful to actually exchange the intermediate constraint trees to other softwares/computers or just generally format them into JSON/YAML for nicer reading.

This PR should do it.