### PR TITLE
declare the public API, fix a few other things

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+ignore = ["src/public_api.jl"] # temporary workaround to be removed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstraintTrees"
 uuid = "5515826b-29c3-47a5-8849-8513ac836620"
 authors = ["The developers of ConstraintTrees.jl"]
-version = "1.6.0"
+version = "1.7.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/docs/src/0-quickstart.jl
+++ b/docs/src/0-quickstart.jl
@@ -128,7 +128,7 @@ C.pretty(s)
 import JuMP
 function optimized_vars(cs::C.ConstraintTree, objective::C.LinearValue, optimizer)
     model = JuMP.Model(optimizer)
-    JuMP.@variable(model, x[1:C.var_count(cs)])
+    JuMP.@variable(model, x[1:C.variable_count(cs)])
     JuMP.@objective(model, JuMP.MAX_SENSE, C.substitute(objective, x))
     C.traverse(cs) do c
         b = c.bound

--- a/docs/src/1-metabolic-modeling.jl
+++ b/docs/src/1-metabolic-modeling.jl
@@ -250,7 +250,7 @@ st.transformed_coords
 import JuMP
 function optimized_vars(cs::C.ConstraintTree, objective::C.LinearValue, optimizer)
     model = JuMP.Model(optimizer)
-    JuMP.@variable(model, x[1:C.var_count(cs)])
+    JuMP.@variable(model, x[1:C.variable_count(cs)])
     JuMP.@objective(model, JuMP.MAX_SENSE, C.substitute(objective, x))
     C.traverse(cs) do c
         b = c.bound
@@ -499,7 +499,7 @@ c.community.species1.handicap
 # First, let's create a list of all variables in the model that we can use for
 # substitution:
 
-vars = [C.variable(; idx).value for idx = 1:C.var_count(c)]
+vars = [C.variable(; idx).value for idx = 1:C.variable_count(c)]
 
 # Now we use a bit of the knowledge about the model structure -- the handicaps
 # constraint single variables, so we can substitute for them directly. (If the
@@ -522,9 +522,9 @@ c_simplified = C.prune_variables(C.substitute(c, vars))
 
 # The result contains exactly 2 variables less than the original community:
 
-(C.var_count(c), C.var_count(c_simplified))
+(C.variable_count(c), C.variable_count(c_simplified))
 
-@test C.var_count(c) == C.var_count(c_simplified) + 2 #src
+@test C.variable_count(c) == C.variable_count(c_simplified) + 2 #src
 
 # The constraints that were substituted for are, at this point, roughly
 # equivalent to saying `0 == 0`, and most solvers will simply drop them as

--- a/docs/src/1-metabolic-modeling.jl
+++ b/docs/src/1-metabolic-modeling.jl
@@ -42,11 +42,7 @@ ecoli = SBML.readSBML("e_coli_core.xml")
 c = C.variables(keys = Symbol.(keys(ecoli.reactions)))
 
 #md # !!! info "Pretty-printing"
-#md #     By default, Julia shows relatively long namespace prefixes before all
-#md #     identifiers, which clutters the output. You can import individual
-#md #     names form `ConstraintTrees` package to improve the pretty-printing,
-#md #     using e.g.:
-#md #     `import ConstraintTrees: Constraint, Tree, LinearValue`.
+#md #     By default, Julia shows relatively long namespace prefixes before all identifiers, which substantially clutters the output. To improve the pretty-printing, all type names are marked as exported from the package, and you can import them via `using ConstraintTrees`.
 
 @test length(C.elems(c)) == length(ecoli.reactions) #src
 

--- a/docs/src/2-quadratic-optimization.jl
+++ b/docs/src/2-quadratic-optimization.jl
@@ -116,7 +116,7 @@ C.pretty(s; format_label = x -> join(x, '.'))
 import JuMP
 function quad_optimized_vars(cs::C.ConstraintTree, objective::C.Value, optimizer)
     model = JuMP.Model(optimizer)
-    JuMP.@variable(model, x[1:C.var_count(cs)])
+    JuMP.@variable(model, x[1:C.variable_count(cs)])
     JuMP.@objective(model, JuMP.MAX_SENSE, C.substitute(objective, x))
     C.traverse(cs) do c
         b = c.bound

--- a/docs/src/3-mixed-integer-optimization.jl
+++ b/docs/src/3-mixed-integer-optimization.jl
@@ -75,7 +75,7 @@ end
 
 function milp_optimized_vars(cs::C.ConstraintTree, objective::C.Value, optimizer)
     model = JuMP.Model(optimizer)
-    JuMP.@variable(model, x[1:C.var_count(cs)])
+    JuMP.@variable(model, x[1:C.variable_count(cs)])
     JuMP.@objective(model, JuMP.MAX_SENSE, C.substitute(objective, x))
     C.traverse(cs) do c
         isnothing(c.bound) || jump_constraint(model, x, c.value, c.bound)

--- a/docs/src/4-functional-tree-processing.jl
+++ b/docs/src/4-functional-tree-processing.jl
@@ -254,7 +254,7 @@ end
 
 C.pretty(x)
 
-@test C.var_count(x) == 6 #src
+@test C.variable_count(x) == 6 #src
 @test isapprox(x.x.x.bound.lower, -0.055) #src
 
 # (Note that the variable indexes in subtrees are now different from each
@@ -359,16 +359,16 @@ C.pretty(filtered)
 # state, where there are indexes allocated for variables that are no longer
 # used!
 
-C.var_count(filtered)
+C.variable_count(filtered)
 
 # To fix the issue, it is possible to "squash" the variable indexes using
 # [`prune_variables`](@ref ConstraintTrees.prune_variables):
 
 pruned = C.prune_variables(filtered)
 
-C.var_count(pruned)
+C.variable_count(pruned)
 
-@test C.var_count(pruned) == 3 #src
+@test C.variable_count(pruned) == 3 #src
 
 # Note that after the pruning and renumbering, the involved constraint trees
 # are no longer compatible, and should not be combined with `*`. As an
@@ -383,7 +383,7 @@ pruned_qv = C.prune_variables(x.y.x.value * x.z.y.value)
 
 (pruned_qv, x.y.x.value * x.z.y.value)
 
-@test C.var_count(pruned_qv) == 2 #src
+@test C.variable_count(pruned_qv) == 2 #src
 @test pruned_qv.idxs == (x.x.x.value * x.x.y.value).idxs #src
 @test pruned_qv.weights == (x.x.x.value * x.x.y.value).weights #src
 
@@ -402,13 +402,13 @@ x.x.y.value = x.x.y.value + x.x.x.value * x.x.x.value - x.x.y.value
 
 #
 
-C.var_count(C.prune_variables(x))
+C.variable_count(C.prune_variables(x))
 
-@test C.var_count(C.prune_variables(x)) == 6 #src
+@test C.variable_count(C.prune_variables(x)) == 6 #src
 
 # After the zero-weight variable references are dropped, the pruning behaves as
 # desired:
 
-C.var_count(C.prune_variables(C.drop_zeros(x)))
+C.variable_count(C.prune_variables(C.drop_zeros(x)))
 
-@test C.var_count(C.prune_variables(C.drop_zeros(x))) == 5 #src
+@test C.variable_count(C.prune_variables(C.drop_zeros(x))) == 5 #src

--- a/src/ConstraintTrees.jl
+++ b/src/ConstraintTrees.jl
@@ -68,4 +68,20 @@ include("tree.jl")
 include("constraint_tree.jl")
 include("pretty.jl")
 
+# API definition
+#
+# ConstraintTrees export only the main used type names (they generally don't
+# collide and `using ConstraintTrees` would help a lot with neater formatting
+# of data print-outs)
+
+export LinearValue, QuadraticValue
+export Between, EqualTo
+export Constraint, Tree, ConstraintTree
+
+# For sufficiently new Julias, we also include the `public` markers for
+# non-exported but used names.
+if VERSION >= v"1.11"
+    include("public_api.jl")
+end
+
 end # module ConstraintTrees

--- a/src/ConstraintTrees.jl
+++ b/src/ConstraintTrees.jl
@@ -74,8 +74,8 @@ include("pretty.jl")
 # collide and `using ConstraintTrees` would help a lot with neater formatting
 # of data print-outs)
 
-export LinearValue, QuadraticValue
-export Between, EqualTo
+export Value, LinearValue, QuadraticValue
+export Bound, Between, EqualTo
 export Constraint, Tree, ConstraintTree
 
 # For sufficiently new Julias, we also include the `public` markers for

--- a/src/constraint_tree.jl
+++ b/src/constraint_tree.jl
@@ -87,13 +87,6 @@ const ConstraintTreeElem = Union{Constraint,ConstraintTree}
 #
 
 """
-Old name for [`variable_count`](@ref).
-
-**Deprecation warning:** This will be removed in a future release.
-"""
-const var_count = variable_count
-
-"""
 $(TYPEDSIGNATURES)
 
 Find the expected count of variables in a [`Constraint`](@ref).
@@ -124,11 +117,11 @@ O(1) operation, relying on the co-lexicographical ordering of indexes.)
 variable_count(x::QuadraticValue) = isempty(x.idxs) ? 0 : last(last(x.idxs))
 
 """
-Old name for [`increase_variable_index`](@ref).
+Old name for [`variable_count`](@ref).
 
 **Deprecation warning:** This will be removed in a future release.
 """
-const incr_var_idx = increase_variable_index
+const var_count = variable_count
 
 """
 $(TYPEDSIGNATURES)
@@ -138,11 +131,11 @@ Internal helper for manipulating variable indices.
 increase_variable_index(x::Int, incr::Int) = x == 0 ? 0 : x + incr
 
 """
-Old name for [`increase_variable_indexes`](@ref).
+Old name for [`increase_variable_index`](@ref).
 
 **Deprecation warning:** This will be removed in a future release.
 """
-const incr_var_idxs = increase_variable_indexes
+const incr_var_idx = increase_variable_index
 
 """
 $(TYPEDSIGNATURES)
@@ -179,6 +172,13 @@ increase_variable_indexes(x::QuadraticValue, incr::Int) = QuadraticValue(
     idxs = broadcast(ii -> increase_variable_index.(ii, incr), x.idxs),
     weights = x.weights,
 )
+
+"""
+Old name for [`increase_variable_indexes`](@ref).
+
+**Deprecation warning:** This will be removed in a future release.
+"""
+const incr_var_idxs = increase_variable_indexes
 
 """
 $(TYPEDSIGNATURES)

--- a/src/constraint_tree.jl
+++ b/src/constraint_tree.jl
@@ -87,18 +87,25 @@ const ConstraintTreeElem = Union{Constraint,ConstraintTree}
 #
 
 """
+Old name for [`variable_count`](@ref).
+
+**Deprecation warning:** This will be removed in a future release.
+"""
+const var_count = variable_count
+
+"""
 $(TYPEDSIGNATURES)
 
 Find the expected count of variables in a [`Constraint`](@ref).
 """
-var_count(x::Constraint) = var_count(x.value)
+variable_count(x::Constraint) = variable_count(x.value)
 
 """
 $(TYPEDSIGNATURES)
 
 Find the expected count of variables in a [`ConstraintTree`](@ref).
 """
-var_count(x::ConstraintTree) = isempty(x) ? 0 : maximum(var_count.(values(x)))
+variable_count(x::ConstraintTree) = isempty(x) ? 0 : maximum(variable_count.(values(x)))
 
 """
 $(TYPEDSIGNATURES)
@@ -106,7 +113,7 @@ $(TYPEDSIGNATURES)
 Find the expected count of variables in a [`LinearValue`](@ref). (This is a
 O(1) operation, relying on the ordering of the indexes.)
 """
-var_count(x::LinearValue) = isempty(x.idxs) ? 0 : last(x.idxs)
+variable_count(x::LinearValue) = isempty(x.idxs) ? 0 : last(x.idxs)
 
 """
 $(TYPEDSIGNATURES)
@@ -114,14 +121,28 @@ $(TYPEDSIGNATURES)
 Find the expected count of variables in a [`QuadraticValue`](@ref). (This is a
 O(1) operation, relying on the co-lexicographical ordering of indexes.)
 """
-var_count(x::QuadraticValue) = isempty(x.idxs) ? 0 : last(last(x.idxs))
+variable_count(x::QuadraticValue) = isempty(x.idxs) ? 0 : last(last(x.idxs))
+
+"""
+Old name for [`increase_variable_index`](@ref).
+
+**Deprecation warning:** This will be removed in a future release.
+"""
+const incr_var_idx = increase_variable_index
 
 """
 $(TYPEDSIGNATURES)
 
 Internal helper for manipulating variable indices.
 """
-incr_var_idx(x::Int, incr::Int) = x == 0 ? 0 : x + incr
+increase_variable_index(x::Int, incr::Int) = x == 0 ? 0 : x + incr
+
+"""
+Old name for [`increase_variable_indexes`](@ref).
+
+**Deprecation warning:** This will be removed in a future release.
+"""
+const incr_var_idxs = increase_variable_indexes
 
 """
 $(TYPEDSIGNATURES)
@@ -129,8 +150,8 @@ $(TYPEDSIGNATURES)
 Offset all variable indexes in a [`ConstraintTree`](@ref) by the given
 increment.
 """
-incr_var_idxs(x::ConstraintTree, incr::Int) =
-    ConstraintTree(k => incr_var_idxs(v, incr) for (k, v) in x)
+increase_variable_indexes(x::ConstraintTree, incr::Int) =
+    ConstraintTree(k => increase_variable_indexes(v, incr) for (k, v) in x)
 
 """
 $(TYPEDSIGNATURES)
@@ -138,24 +159,24 @@ $(TYPEDSIGNATURES)
 Offset all variable indexes in a [`ConstraintTree`](@ref) by the given
 increment.
 """
-incr_var_idxs(x::Constraint, incr::Int) =
-    Constraint(value = incr_var_idxs(x.value, incr), bound = x.bound)
+increase_variable_indexes(x::Constraint, incr::Int) =
+    Constraint(value = increase_variable_indexes(x.value, incr), bound = x.bound)
 
 """
 $(TYPEDSIGNATURES)
 
 Offset all variable indexes in a [`LinearValue`](@ref) by the given increment.
 """
-incr_var_idxs(x::LinearValue, incr::Int) =
-    LinearValue(idxs = incr_var_idx.(x.idxs, incr), weights = x.weights)
+increase_variable_indexes(x::LinearValue, incr::Int) =
+    LinearValue(idxs = increase_variable_index.(x.idxs, incr), weights = x.weights)
 
 """
 $(TYPEDSIGNATURES)
 
 Offset all variable indexes in a [`QuadraticValue`](@ref) by the given increment.
 """
-incr_var_idxs(x::QuadraticValue, incr::Int) = QuadraticValue(
-    idxs = broadcast(ii -> incr_var_idx.(ii, incr), x.idxs),
+increase_variable_indexes(x::QuadraticValue, incr::Int) = QuadraticValue(
+    idxs = broadcast(ii -> increase_variable_index.(ii, incr), x.idxs),
     weights = x.weights,
 )
 
@@ -239,8 +260,8 @@ drop_zeros(x::QuadraticValue) =
 Base.:^(pfx::Symbol, x::Constraint) = ConstraintTree(elems = SortedDict(pfx => x))
 
 function Base.:+(a::ConstraintTree, b::ConstraintTree)
-    offset = var_count(a)
-    a * incr_var_idxs(b, offset)
+    offset = variable_count(a)
+    a * increase_variable_indexes(b, offset)
 end
 
 Base.:*(a::ConstraintTree, b::Constraint) =

--- a/src/constraint_tree.jl
+++ b/src/constraint_tree.jl
@@ -215,7 +215,7 @@ function prune_variables(x)
     push!(vars, 0)
     vv = collect(vars)
     @assert vv[1] == 0 "variable indexes are broken"
-    return renumber_variables(x, SortedDict(vv .=> 0:length(vv)-1))
+    return renumber_variables(x, SortedDict(vv .=> 0:(length(vv)-1)))
 end
 
 """

--- a/src/public_api.jl
+++ b/src/public_api.jl
@@ -30,11 +30,11 @@ public value
 public elems
 public map, imap
 public mapreduce, imapreduce
-public traverse,itraverse
-public filter,ifilter
+public traverse, itraverse
+public filter, ifilter
 public filter_leaves, ifilter_leaves
-public zip,izip
-public merge,imerge
+public zip, izip
+public merge, imerge
 
 # constraint-tree things
 public variable_count

--- a/src/public_api.jl
+++ b/src/public_api.jl
@@ -38,16 +38,12 @@ public merge, imerge
 
 # constraint-tree things
 public variable_count
-public increase_variable_idx
-public increase_variable_idxs
+public increase_variable_index, increase_variable_indexes
 public collect_variables!
 public prune_variables
 public renumber_variables
 public drop_zeros
-public variable
-public variables
-public variables_for
-public variables_ifor
+public variable, variables
 
 # prettification
 public pretty

--- a/src/public_api.jl
+++ b/src/public_api.jl
@@ -1,0 +1,53 @@
+
+# Copyright (c) 2024, University of Luxembourg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: this file is only included if Julia version is >= 1.11
+
+# values
+public preduce
+public squared
+public substitute
+public sum
+
+# constraints
+public bound
+public substitute_values
+public value
+
+# tree things
+public elems
+public map, imap
+public mapreduce, imapreduce
+public traverse,itraverse
+public filter,ifilter
+public filter_leaves, ifilter_leaves
+public zip,izip
+public merge,imerge
+
+# constraint-tree things
+public variable_count
+public increase_variable_idx
+public increase_variable_idxs
+public collect_variables!
+public prune_variables
+public renumber_variables
+public drop_zeros
+public variable
+public variables
+public variables_for
+public variables_ifor
+
+# prettification
+public pretty

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -89,7 +89,7 @@ end
     @test_throws ErrorException ct1 * ct1
     @test_throws ErrorException :a^ct1 * ct1
     @test_throws ErrorException ct1 * :a^ct1
-    @test C.var_count(C.variables_for(_ -> C.EqualTo(0.0), ct1 + ct2)) == 4
+    @test C.variable_count(C.variables_for(_ -> C.EqualTo(0.0), ct1 + ct2)) == 4
 
     delete!(ct1, "a")
     ct2["a"] = ct1["b"]

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -142,7 +142,7 @@ end
     @test occursin("[2]", s(ct.x.b))
     @test occursin("[1.0]", s(ct.x.a))
 
-    vt = C.substitute_values(ct, [1.0, 2.0])
+    vt = C.substitute_values(ct, [1.0, 2.0, 3.0, 4.0])
     @test occursin("Tree{Float64}", s(vt))
 
     p(x) = iob(C.pretty, x)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -136,11 +136,14 @@ end
     @test length(C.ADWrap(ct)) == length(ct)
     @test occursin(":x", s(ct))
     @test occursin(":y", s(ct))
-    @test occursin(r"Tree{[a-zA-Z.]*Constraint}", s(ct))
+    @test occursin("ConstraintTree(", s(ct))
     @test occursin("2 elements", s(ct.x))
     @test occursin(":a", s(ct.x))
     @test occursin("[2]", s(ct.x.b))
     @test occursin("[1.0]", s(ct.x.a))
+
+    vt = substitute_values(ct, [1.0, 2.0])
+    @test occursin("Tree{Float64}", s(vt))
 
     p(x) = iob(C.pretty, x)
     @test p(zero(C.LinearValue)) == "0"

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -142,7 +142,7 @@ end
     @test occursin("[2]", s(ct.x.b))
     @test occursin("[1.0]", s(ct.x.a))
 
-    vt = substitute_values(ct, [1.0, 2.0])
+    vt = C.substitute_values(ct, [1.0, 2.0])
     @test occursin("Tree{Float64}", s(vt))
 
     p(x) = iob(C.pretty, x)


### PR DESCRIPTION
We unfortunately need to wait for some thing to stabilize around `public` (mainly JuliaFormatter) before merging this cleanly.

From major changes, we recommend new full names for the original "shortened" `var_count` etc. ~~Will need to test if this breaks other people's overloading. might remove.~~ EDIT: it works