### PR TITLE
implement tree pretty-printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstraintTrees"
 uuid = "5515826b-29c3-47a5-8849-8513ac836620"
 authors = ["The developers of ConstraintTrees.jl"]
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/docs/src/0-quickstart.jl
+++ b/docs/src/0-quickstart.jl
@@ -273,9 +273,10 @@ end
 #md # !!! info "High-level constraint tree manipulation"
 #md #     There is also a [dedicated example](4-functional-tree-processing.md) with many more useful functions like [`zip`](@ref ConstraintTrees.zip) above.
 
-# The complete system now looks like this:
+# The complete system (with a slightly humanized variable formatting added for
+# legibility) now looks like this:
 
-C.pretty(c)
+C.pretty(c, format_variable = i -> i == 0 ? "" : " " * ('a' + i - 1))
 
 # Finally, let's see how much money can we make from having the factory
 # supported by our fields in total!

--- a/docs/src/0-quickstart.jl
+++ b/docs/src/0-quickstart.jl
@@ -77,6 +77,13 @@ s[:area].barley
 
 s["area"]["barley"]
 
+# The default rendering of constraint trees is mildly inconvenient because of
+# efficiency constraints and the amount of structural and type information that
+# it must convey. To see the data structure at full scale, we can use
+# [`pretty`](@ref ConstraintTrees.pretty):
+
+C.pretty(s)
+
 # Now let's start rewriting the problem into the constraint-tree-ish
 # description. First, we only have 100 square kilometers of area:
 
@@ -105,6 +112,10 @@ s *=
 # need to actually put a constraint bound there):
 
 s *= :profit^C.Constraint(s.area.wheat.value * 350 + s.area.barley.value * 550)
+
+# Finally, the whole system looks like this:
+
+C.pretty(s)
 
 # ## Solving the system with JuMP
 #
@@ -157,13 +168,17 @@ optimal_s.profit
 
 @test isapprox(optimal_s.profit, 48333.33333333334) #src
 
-# The occupied area for each crop:
+# ...as well as the occupied area for each crop:
 
 optimal_s.area
 
-# The consumed resources:
+# ...and the consumed resources:
 
 optimal_s.resources
+
+# Pretty-printing works also for trees with results:
+
+C.pretty(optimal_s)
 
 # ## Increasing the complexity
 #
@@ -257,6 +272,10 @@ end
 
 #md # !!! info "High-level constraint tree manipulation"
 #md #     There is also a [dedicated example](4-functional-tree-processing.md) with many more useful functions like [`zip`](@ref ConstraintTrees.zip) above.
+
+# The complete system now looks like this:
+
+C.pretty(c)
 
 # Finally, let's see how much money can we make from having the factory
 # supported by our fields in total!

--- a/docs/src/2-quadratic-optimization.jl
+++ b/docs/src/2-quadratic-optimization.jl
@@ -102,6 +102,10 @@ s *=
 # definition of `point` would not be duplicated, and various non-interesting
 # logic errors would follow.)
 
+# The complete system (with slightly humanized variable formatting) now looks
+# like this:
+C.pretty(s, format_variable = i -> i == 0 ? "" : " " * ('a' + i - 1))
+
 # ## Solving quadratic systems with JuMP
 #
 # To solve the above system, we need a matching solver that can work with

--- a/docs/src/2-quadratic-optimization.jl
+++ b/docs/src/2-quadratic-optimization.jl
@@ -102,9 +102,8 @@ s *=
 # definition of `point` would not be duplicated, and various non-interesting
 # logic errors would follow.)
 
-# The complete system (with slightly humanized variable formatting) now looks
-# like this:
-C.pretty(s, format_variable = i -> i == 0 ? "" : " " * ('a' + i - 1))
+# The complete system now looks like this:
+C.pretty(s)
 
 # ## Solving quadratic systems with JuMP
 #

--- a/docs/src/3-mixed-integer-optimization.jl
+++ b/docs/src/3-mixed-integer-optimization.jl
@@ -108,6 +108,24 @@ dices_thrown = C.substitute_values(
 @test isapprox(dices_thrown.first_dice, 6.0) #src
 @test isapprox(dices_thrown.second_dice, 4.0) #src
 
+# ## A note on pretty-printing of custom extensions
+#
+# By default, pretty-printing via [`pretty`](@ref ConstraintTrees.pretty)
+# attempts to fall back to `Base.show` for any value which has no explicit
+# overload of `pretty`. In particular, the bounds in our MILP system are
+# formatted as follows:
+
+C.pretty(dice_system)
+
+# To provide a prettier rendering, it is sufficient to provide a matching
+# overload of [`pretty`](@ref ConstraintTrees.pretty):
+
+function C.pretty(io::IO, x::IntegerFromTo; style_args...)
+    print(io, " ∈ {$(x.from) … $(x.to)}")
+end
+
+C.pretty(dice_system)
+
 # ## A more realistic example with geometry
 #
 # Let's find the size of the smallest right-angled triangle with integer side
@@ -125,6 +143,8 @@ triangle_system =
     :a_less_than_b^C.Constraint(v.b - v.a, (0, Inf)) *
     :b_less_than_c^C.Constraint(v.c - v.b, (0, Inf)) *
     :right_angled^C.Constraint(C.squared(v.a) + C.squared(v.b) - C.squared(v.c), 0.0)
+
+C.pretty(triangle_system, format_variable = i -> ["", "A", "B", "C"][i+1])
 
 # We will need a solver that supports both quadratic and integer optimization:
 import SCIP

--- a/docs/src/4-functional-tree-processing.jl
+++ b/docs/src/4-functional-tree-processing.jl
@@ -305,7 +305,6 @@ constraint_count
 
 C.itraverse(x) do ix, c
     path = join(String.(ix), '/')
-    return #src
     println("$path = $c")
 end;
 

--- a/docs/src/4-functional-tree-processing.jl
+++ b/docs/src/4-functional-tree-processing.jl
@@ -64,7 +64,7 @@ import ConstraintTrees as C
 
 constraints = :point^C.variables(keys = [:x, :y], bounds = C.Between(0, 1))
 
-C.pretty(constriants)
+C.pretty(constraints)
 
 # ## Transforming trees with `map`
 #

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -54,6 +54,6 @@ Pages = ["src/constraint_tree.jl"]
 ## Pretty-printing
 
 ```@autodocs
-modules=[ConstraintTrees]
+Modules = [ConstraintTrees]
 Pages = ["src/pretty.jl"]
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -50,3 +50,10 @@ Pages = ["src/tree.jl"]
 Modules = [ConstraintTrees]
 Pages = ["src/constraint_tree.jl"]
 ```
+
+## Pretty-printing
+
+```@autodocs
+modules=[ConstraintTrees]
+Pages = ["src/pretty.jl"]
+```

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -218,7 +218,7 @@ function pretty_tree(
     child_first_indent = "│ ╰─",
     child_indent = "│   ",
     lastchild_first_indent = "  ╰─",
-    lastchild_indent = "   ",
+    lastchild_indent = "    ",
     kwargs...,
 )
     isempty(pfx0) || print(io, "\n")

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -74,7 +74,7 @@ $(TYPEDSIGNATURES)
 
 Default implementation of [`pretty`](@ref) defaults to `Base.show`.
 """
-pretty(io::IO, x; kwargs...) = show(io, x; kwargs...)
+pretty(io::IO, x; kwargs...) = show(io, x)
 
 """
 $(TYPEDSIGNATURES)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -105,7 +105,7 @@ function pretty(io::IO, x::LinearValue)
     if isempty(x.idxs)
         print(io, "0")
     else
-        join(io, ("$w"*pretty_var(i) for (i, w) in Base.zip(x.idxs, x.weights)), " + ")
+        join(io, ("$w" * pretty_var(i) for (i, w) in Base.zip(x.idxs, x.weights)), " + ")
     end
 end
 
@@ -121,7 +121,7 @@ function pretty(io::IO, x::QuadraticValue)
         join(
             io,
             (
-                "$w"*pretty_var(i)*pretty_var(j) for
+                "$w" * pretty_var(i) * pretty_var(j) for
                 ((i, j), w) in Base.zip(x.idxs, x.weights)
             ),
             " + ",
@@ -170,7 +170,7 @@ Internal helper for prettyprinting variable contributions. Does not print
 anything for the zero "affine" variable.
 """
 function pretty_var(i)
-    if i==0
+    if i == 0
         return ""
     else
         return "*x[$i]"
@@ -195,8 +195,8 @@ function pretty_tree(io::IO, x::Tree, pfx0::String, pfx::String)
         print(io, pfx, "├─", k)
         pretty_tree(io, v, pfx * "│ ╰─", pfx * "│   ")
     end
-    if length(es)>0
-        (k, v)=es[end]
+    if length(es) > 0
+        (k, v) = es[end]
         print(io, pfx, "╰─", k)
         pretty_tree(io, v, pfx * "  ╰─", pfx * "    ")
     end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -235,18 +235,22 @@ function pretty_tree(
         lastchild_indent,
         kwargs...,
     )
-    if length(es) > 1
+    if length(es) == 1
+        (k, v) = es[end]
+        print(io, pfx0, singleton_branch, k)
+        pretty_tree(io, v, pfx * lastchild_first_indent, pfx * lastchild_indent; argpack...)
+    elseif length(es) > 1
         (k, v) = es[begin]
         print(io, pfx0, first_branch, k)
         pretty_tree(io, v, pfx * child_first_indent, pfx * child_indent; argpack...)
-    end
-    for (k, v) in es[(begin+1):(end-1)]
-        print(io, pfx, middle_branch, k)
-        pretty_tree(io, v, pfx * child_first_indent, pfx * child_indent; argpack...)
-    end
-    if length(es) > 0
+
+        for (k, v) in es[(begin+1):(end-1)]
+            print(io, pfx, middle_branch, k)
+            pretty_tree(io, v, pfx * child_first_indent, pfx * child_indent; argpack...)
+        end
+
         (k, v) = es[end]
-        print(io, pfx, length(es) == 1 ? singleton_branch : last_branch, k)
+        print(io, pfx, last_branch, k)
         pretty_tree(io, v, pfx * lastchild_first_indent, pfx * lastchild_indent; argpack...)
     end
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -126,10 +126,11 @@ function pretty(
     x::LinearValue;
     format_variable = default_pretty_var,
     plus_sign = " + ",
+    zero_value = "0",
     kwargs...,
 )
     if isempty(x.idxs)
-        print(io, "0")
+        print(io, zero_value)
     else
         join(
             io,
@@ -149,10 +150,11 @@ function pretty(
     x::QuadraticValue;
     format_variable = default_pretty_var,
     plus_sign = " + ",
+    zero_value = "0",
     kwargs...,
 )
     if isempty(x.idxs)
-        print(io, "0")
+        print(io, zero_value)
     else
         join(
             io,

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -173,7 +173,7 @@ should expect that they are ran right after printing of the [`Value`](@ref)s,
 on the same line.
 """
 function pretty(io::IO, x::Bound; default_bound_separator = "; ", kwargs...)
-    print(io, bound_separator)
+    print(io, default_bound_separator)
     show(io, x)
 end
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -183,7 +183,7 @@ $(TYPEDSIGNATURES)
 Pretty-print an equality bound into the `io`.
 """
 function pretty(io::IO, x::EqualTo; equal_to_sign = "=", kwargs...)
-    print(io, " $equal_sign $(x.equal_to)")
+    print(io, " $equal_to_sign $(x.equal_to)")
 end
 
 """

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -138,7 +138,7 @@ Default pretty-printing of a [`Bound`](@ref). Overloads that print bounds
 should expect that they are ran right after printing of the [`Value`](@ref)s,
 on the same line.
 """
-function pretty(io::IO, x::Bound; bound_separator = "; ")
+function pretty(io::IO, x::Bound; default_bound_separator = "; ", kwargs...)
     print(io, bound_separator)
     show(io, x)
 end
@@ -148,7 +148,7 @@ $(TYPEDSIGNATURES)
 
 Pretty-print an equality bound into the `io`.
 """
-function pretty(io::IO, x::EqualTo; equal_to_sign = "=")
+function pretty(io::IO, x::EqualTo; equal_to_sign = "=", kwargs...)
     print(io, " $equal_sign $(x.equal_to)")
 end
 
@@ -157,8 +157,8 @@ $(TYPEDSIGNATURES)
 
 Pretty-print an interval bound into the `io`.
 """
-function pretty(io::IO, x::Between; in_interval_sign = "∈")
-    print(io, " $between_sign [$(x.lower), $(x.upper)]")
+function pretty(io::IO, x::Between; in_interval_sign = "∈", kwargs...)
+    print(io, " $in_interval_sign [$(x.lower), $(x.upper)]")
 end
 
 #

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -212,6 +212,7 @@ function pretty_tree(
     x::Tree,
     pfx0::String,
     pfx::String;
+    singleton_branch = "──",
     first_branch = "┬─",
     middle_branch = "├─",
     last_branch = "╰─",
@@ -224,6 +225,7 @@ function pretty_tree(
     isempty(pfx0) || print(io, "\n")
     es = collect(elems(x))
     argpack = (;
+        singleton_branch,
         first_branch,
         middle_branch,
         last_branch,
@@ -244,7 +246,7 @@ function pretty_tree(
     end
     if length(es) > 0
         (k, v) = es[end]
-        print(io, pfx, last_branch, k)
+        print(io, pfx, length(es) == 1 ? singleton_branch : last_branch, k)
         pretty_tree(io, v, pfx * lastchild_first_indent, pfx * lastchild_indent; argpack...)
     end
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -101,13 +101,41 @@ end
 """
 $(TYPEDSIGNATURES)
 
+Internal helper for prettyprinting variable contributions; default value of
+`format_variable` keyword argument in [`pretty`](@ref).
+
+If there should be multiplication operators, the implementation `format_variable` is
+supposed to prefix the variable contribution. This should not print anything
+for the zero "affine" variable.
+"""
+function default_pretty_var(i::Int)
+    if i == 0
+        return ""
+    else
+        return "*x[$i]"
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Pretty-print a linear value into the `io`.
 """
-function pretty(io::IO, x::LinearValue; kwargs...)
+function pretty(
+    io::IO,
+    x::LinearValue;
+    format_variable = default_pretty_var,
+    plus_sign = " + ",
+    kwargs...,
+)
     if isempty(x.idxs)
         print(io, "0")
     else
-        join(io, ("$w" * pretty_var(i) for (i, w) in Base.zip(x.idxs, x.weights)), " + ")
+        join(
+            io,
+            (string(w) * format_variable(i) for (i, w) in Base.zip(x.idxs, x.weights)),
+            plus_sign,
+        )
     end
 end
 
@@ -116,17 +144,23 @@ $(TYPEDSIGNATURES)
 
 Pretty-print a quadratic value into the `io`.
 """
-function pretty(io::IO, x::QuadraticValue; kwargs...)
+function pretty(
+    io::IO,
+    x::QuadraticValue;
+    format_variable = default_pretty_var,
+    plus_sign = " + ",
+    kwargs...,
+)
     if isempty(x.idxs)
         print(io, "0")
     else
         join(
             io,
             (
-                "$w" * pretty_var(i) * pretty_var(j) for
+                string(w) * format_variable(i) * format_variable(j) for
                 ((i, j), w) in Base.zip(x.idxs, x.weights)
             ),
-            " + ",
+            plus_sign,
         )
     end
 end
@@ -162,22 +196,8 @@ function pretty(io::IO, x::Between; in_interval_sign = "∈", kwargs...)
 end
 
 #
-# Pretty-printing helpers
+# Drawing of the pretty tree structure
 #
-
-"""
-$(TYPEDSIGNATURES)
-
-Internal helper for prettyprinting variable contributions. Does not print
-anything for the zero "affine" variable.
-"""
-function pretty_var(i)
-    if i == 0
-        return ""
-    else
-        return "*x[$i]"
-    end
-end
 
 """
 $(TYPEDSIGNATURES)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -125,10 +125,10 @@ end
     ct = C.variables(keys = [:a, :b])
     ct = :x^ct + :y^ct
 
-    iob(f, args...) = begin
-        iob = IOBuffer()
-        f(iob, args...)
-        String(take!(iob))
+    function iob(f, args...)
+        buf = IOBuffer()
+        f(buf, args...)
+        String(take!(buf))
     end
 
     s(x) = iob(show, MIME"text/plain"(), x)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -125,11 +125,13 @@ end
     ct = C.variables(keys = [:a, :b])
     ct = :x^ct + :y^ct
 
-    s(x) = begin
+    iob(f, args...) = begin
         iob = IOBuffer()
-        show(iob, MIME"text/plain"(), x)
+        f(iob, args...)
         String(take!(iob))
     end
+
+    s(x) = iob(show, MIME"text/plain"(), x)
 
     @test length(C.ADWrap(ct)) == length(ct)
     @test occursin(":x", s(ct))
@@ -139,4 +141,8 @@ end
     @test occursin(":a", s(ct.x))
     @test occursin("[2]", s(ct.x.b))
     @test occursin("[1.0]", s(ct.x.a))
+
+    p(x) = iob(C.pretty, x)
+    @test p(zero(C.LinearValue)) == "0"
+    @test p(zero(C.QuadraticValue)) == "0"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,28 +16,37 @@
 import ConstraintTrees
 using Test
 
+macro nostdout(x)
+    quote
+        orig_stdout = Base.stdout
+        Base.stdout = IOBuffer()
+        $x
+        Base.stdout = orig_stdout
+    end
+end
+
 @testset "ConstraintTrees tests" begin
     @testset "Metabolic modeling" begin
-        include("../docs/src/1-metabolic-modeling.jl")
+        @nostdout include("../docs/src/1-metabolic-modeling.jl")
     end
 
     @testset "Quadratic optimization" begin
-        include("../docs/src/2-quadratic-optimization.jl")
+        @nostdout include("../docs/src/2-quadratic-optimization.jl")
     end
 
     @testset "Mixed-integer optimization" begin
-        include("../docs/src/3-mixed-integer-optimization.jl")
+        @nostdout include("../docs/src/3-mixed-integer-optimization.jl")
     end
 
     @testset "Functional tree processing" begin
-        include("../docs/src/4-functional-tree-processing.jl")
+        @nostdout include("../docs/src/4-functional-tree-processing.jl")
     end
 
     @testset "JuMP integration improvements" begin
-        include("../docs/src/5-jump-integration.jl")
+        @nostdout include("../docs/src/5-jump-integration.jl")
     end
 
     @testset "Miscellaneous methods" begin
-        include("misc.jl")
+        @nostdout include("misc.jl")
     end
 end


### PR DESCRIPTION
:santa: 

Looks like this:
```
┬─ellipse
│ ╰─┬─in_area: 100.0 + 0.25*x[1]*x[1] + -20.0*x[2] + 1.0*x[2]*x[2] ∈ [-Inf, 1.0]
│   ╰─point
│     ╰─┬─x: 1.0*x[1]
│       ╰─y: 1.0*x[2]
├─line
│   ╰─point
│     ╰─┬─x: 2.0*x[3]
│       ╰─y: 1.0*x[3]
╰─objective: 1.0*x[1]*x[1] + 1.0*x[2]*x[2] + -4.0*x[1]*x[3] + -2.0*x[2]*x[3] + 5.0*x[3]*x[3]


┬─original_coords
│ ╰─┬─x: 1.0
│   ╰─y: 5.0
╰─transformed_coords
  ╰─┬─xt: 11.0
    ╰─yt: -0.19999999999999996
```

Still needs tests and docs.

Will need additional `public` interface in #45 .