### PR TITLE
implement some matrix operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstraintTrees"
 uuid = "5515826b-29c3-47a5-8849-8513ac836620"
 authors = ["The developers of ConstraintTrees.jl"]
-version = "1.9.0"
+version = "1.10.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/docs/src/3-mixed-integer-optimization.jl
+++ b/docs/src/3-mixed-integer-optimization.jl
@@ -148,15 +148,14 @@ C.pretty(triangle_system, format_variable = i -> ["", "A", "B", "C"][i+1])
 
 # We will need a solver that supports both quadratic and integer optimization:
 import SCIP
-triangle_sides =
-    C.substitute_values(
+triangle_sides = C.substitute_values(
+    triangle_system,
+    milp_optimized_vars(
         triangle_system,
-        milp_optimized_vars(
-            triangle_system,
-            -triangle_system.circumference.value,
-            SCIP.Optimizer,
-        ),
-    ).sides
+        -triangle_system.circumference.value,
+        SCIP.Optimizer,
+    ),
+).sides
 
 @test isapprox(triangle_sides.a, 3.0) #src
 @test isapprox(triangle_sides.b, 4.0) #src

--- a/docs/src/4-functional-tree-processing.jl
+++ b/docs/src/4-functional-tree-processing.jl
@@ -424,3 +424,67 @@ C.variable_count(C.prune_variables(x))
 C.variable_count(C.prune_variables(C.drop_zeros(x)))
 
 @test C.variable_count(C.prune_variables(C.drop_zeros(x))) == 5 #src
+
+# ## Converting to and from vector representations
+#
+# Often it is useful to look at the constraint system via the "matrix" view as
+# common in mathematical optimization. Functions [`deflate`](@ref
+# ConstraintTrees.deflate) and [`reinflate`](@ref ConstraintTrees.reinflate)
+# provide a sensible way to convert the trees into vectors of constraints and
+# back, giving more possibilities to work with the tree contents.
+#
+# In particular, trees that only contain linear values may be represented as
+# matrices. For demonstration, one may convert the following (slightly fixed)
+# tree to a matrix, a vector of lower and upper bounds, and a vector of
+# constraint "row" names:
+
+x.x.y.value = 3*x.x.x.value + 2 * x.y.y.value + 0.5 * x.z.x.value
+C.pretty(x)
+
+# `deflate` serves as a conversion tool to vectors:
+
+C.deflate(x, C.MaybeBound) do c
+    c.bound
+end
+
+# To extract a proper matrix, one has to convert the linear values to actual
+# vectors:
+
+import SparseArrays: sparse, sparsevec, SparseVector
+
+n_vars = C.variable_count(x)
+vecs = C.deflate(x, SparseVector{Float64}) do c
+    sparsevec(c.value.idxs, c.value.weights, n_vars)
+end;
+sparse(hcat(vecs...)')
+
+# Finally, to extract everything at once with proper identifiers, it is useful
+# to use [`ideflate`](@ref ConstraintTrees.ideflate):
+rows = C.ideflate(x, Pair) do i, c
+    join(i, "/") => (sparsevec(c.value.idxs, c.value.weights, n_vars), c.bound)
+end;
+
+# To convert to the usual form, we use some helper functions:
+lb(x::C.EqualTo) = x.equal_to
+ub(x::C.EqualTo) = x.equal_to
+lb(x::C.Between) = x.lower_bound
+ub(x::C.Between) = x.upper_bound
+
+# This gives good row "identifiers":
+row_names = first.(rows)
+# ...as well as lower and upper bound vectors:
+row_bounds = let constraints = last.(last.(rows))
+    (lb.(constraints), ub.(constraints))
+end
+# ...and the "linear programming" matrix:
+matrix = sparse(hcat(first.(last.(rows))...)')
+
+@test size(matrix) == (6, 6) #src
+@test isapprox(sum(matrix), 10.5) #src
+
+# The vector data can be re-inserted into "same-shaped" trees. For example, one
+# can make a tree where variable references sum to 1 for each variable:
+weighted_matrix = matrix ./ max.(eps(), sum(matrix, dims = 1))
+
+# The weighted matrix is then converted to a vector and re-inserted:
+C.reinflate(x, C.LinearValue.(sparse.(eachrow(weighted_matrix)))) |> C.pretty

--- a/src/constraint_tree.jl
+++ b/src/constraint_tree.jl
@@ -251,9 +251,9 @@ Remove variable references from all [`Value`](@ref)s in the given object
 drop_zeros(x::Tree{T}) where {T} = ConstraintTree(k => drop_zeros(v) for (k, v) in x)
 drop_zeros(x::Constraint) = Constraint(drop_zeros(x.value), x.bound)
 drop_zeros(x::LinearValueT) =
-    LinearValueT(idxs = x.idxs[x.weights.!=0], weights = x.weights[x.weights.!=0])
+    LinearValueT(idxs = x.idxs[x.weights .!= 0], weights = x.weights[x.weights .!= 0])
 drop_zeros(x::QuadraticValueT) =
-    QuadraticValueT(idxs = x.idxs[x.weights.!=0], weights = x.weights[x.weights.!=0])
+    QuadraticValueT(idxs = x.idxs[x.weights .!= 0], weights = x.weights[x.weights .!= 0])
 
 #
 # Algebraic construction

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -145,6 +145,26 @@ end
 """
 $(TYPEDSIGNATURES)
 
+Like [`deflate`](@ref), but the function `f` also receives the full tree path
+in the first argument.
+"""
+function ideflate(f, x::Tree{T}, ::Type{U} = T)::Vector{U} where {T,U}
+    count = 0
+    traverse(x) do _
+        count += 1
+    end
+    res = Vector{U}(undef, count)
+    i = 1
+    itraverse(x) do path, c
+        res[i] = f(path, c)
+        i += 1
+    end
+    res
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Insert a vector of elements into the "values" of a [`Tree`](@ref). The order of
 elements in the input vector is given by [`deflate`](@ref).
 """

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -489,8 +489,8 @@ Index-reporting variant of [`merge`](@ref) (see [`imap`](@ref) for reference).
 function imerge(f, x, y, ::Type{T} = Constraint) where {T}
     go(ix, x::OptionalTree, y::OptionalTree) = Tree{T}(
         k => v for (k, v) in (
-            k => go(tuple(ix..., k), optional_tree_get(x, k), optional_tree_get(y, k)) for
-            k in union(optional_tree_keys(x), optional_tree_keys(y))
+            k => go(tuple(ix..., k), optional_tree_get(x, k), optional_tree_get(y, k))
+            for k in union(optional_tree_keys(x), optional_tree_keys(y))
         ) if !ismissing(v)
     )
     go(ix, x, y) = f(ix, x, y)

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2023-2024, University of Luxembourg
+# Copyright (c) 2023-2025, University of Luxembourg
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -115,6 +115,45 @@ Base.merge(a::Base.Callable, d::Tree, others::Tree...) = Base.mergewith(a, d, ot
 
 function Base.mergewith(a::Base.Callable, d::Tree{X}, others::Tree...) where {X}
     Tree{X}(elems = mergewith(a, elems(d), elems.(others)...))
+end
+
+#
+# Deflating and re-inflating trees
+#
+
+"""
+$(TYPEDSIGNATURES)
+
+Extract all elements of a [`Tree`](@ref) in order, and return them in a vector
+as transformed by `f`. If the order is not changed, one can re-insert a vector
+of modified elements into the same-shaped tree using [`reinflate`](@ref).
+"""
+function deflate(f, x::Tree{T}, ::Type{U} = T)::Vector{U} where {T,U}
+    count = 0
+    traverse(x) do _
+        count += 1
+    end
+    res = Vector{U}(undef, count)
+    i = 1
+    traverse(x) do c
+        res[i] = f(c)
+        i += 1
+    end
+    res
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Insert a vector of elements into the "values" of a [`Tree`](@ref). The order of
+elements in the input vector is given by [`deflate`](@ref).
+"""
+function reinflate(x::Tree, elems::Vector{T})::Tree{T} where {T}
+    i = 0
+    map(x, T) do _
+        i += 1
+        elems[i]
+    end
 end
 
 #


### PR DESCRIPTION
I wanted to have this code written down somewhere. So we intern the deflate/reinflate functionality from COBREXA, and add a few examples.

From the modeling point of view, this should allow people to easily convert constraint trees to "matrixy" formats such as MPS or even SBML-ish models.