### PR TITLE
Update deps and break out project.toml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,11 @@ jobs:
       - uses: julia-actions/setup-julia@v3
       - uses: julia-actions/cache@v3
       - name: Install dependencies
-        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.add(["Documenter", "Literate"]); '
+        run: |
+          # force copy of the Project.toml from test (normally it's a symlink and julia gets somewhat confused by that)
+          rm -f docs/Project.toml
+          cp test/Project.toml docs
+          julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.add(["Documenter", "Literate"]); '
       - name: Build and deploy
         env:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
       - uses: julia-actions/cache@v3
       - name: Install dependencies
-        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.add(["Documenter", "Literate"]); Pkg.instantiate()'
       - name: Build and deploy
         env:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
       - uses: julia-actions/cache@v3
       - name: Install dependencies
-        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.add(["Documenter", "Literate"]); Pkg.instantiate()'
+        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.add(["Documenter", "Literate"]); '
       - name: Build and deploy
         env:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Remove trailing whitespace
         run: |
           find -name '*.jl' -or -name '*.md' -or -name '*.toml' -or -name '*.yml' | while read filename ; do
+            # skip symlinks
+            if [ -h "$filename" ] ; then continue ; fi
             # remove any trailing spaces
             sed --in-place -e 's/\s*$//' "$filename"
             # add a final newline if missing

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
+Manifest.toml
 /docs/build/
-/Manifest.toml
-
-test/Manifest.toml
-
 *.cov
 .*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /docs/build/
 /Manifest.toml
 
+test/Manifest.toml
+
 *.cov
 .*.swp

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "ConstraintTrees"
 uuid = "5515826b-29c3-47a5-8849-8513ac836620"
 authors = ["The developers of ConstraintTrees.jl"]
-version = "1.11.0"
+version = "1.11.1"
 
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -11,27 +12,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Accessors = "0.1"
-Clarabel = "0.6"
-ConstructionBase = "1.5"
-DataStructures = "0.18"
-DocStringExtensions = "0.8, 0.9"
-GLPK = "1"
-JSON = "1"
-JuMP = "1"
-SBML = "1"
-SCIP = "0.11"
-julia = "1.10"
-
-[extras]
-Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
-Clarabel = "61c947e1-3e6d-4ee4-985a-eec8c727bd6e"
-Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-SBML = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
-SCIP = "82193955-e24f-5292-bf16-6f2c5261a85f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Accessors", "Clarabel", "Downloads", "GLPK", "JSON", "JuMP", "SBML", "SCIP", "Test"]
+ConstructionBase = "1.6"
+DataStructures = "0.19"
+DocStringExtensions = "0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,13 @@ authors = ["The developers of ConstraintTrees.jl"]
 version = "1.11.1"
 
 [deps]
-Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Accessors = "0.1"
-ConstructionBase = "1.6"
-DataStructures = "0.19"
-DocStringExtensions = "0.9"
+ConstructionBase = "1.5, 1.6"
+DataStructures = "0.18, 0.19"
+DocStringExtensions = "0.8, 0.9"
+julia = "1.10"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,16 +1,1 @@
-[deps]
-Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
-Clarabel = "61c947e1-3e6d-4ee4-985a-eec8c727bd6e"
-ConstraintTrees = "5515826b-29c3-47a5-8849-8513ac836620"
-DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
-SBML = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
-SCIP = "82193955-e24f-5292-bf16-6f2c5261a85f"
-
-[compat]
-Documenter = "1"
+../test/Project.toml

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -437,8 +437,8 @@ $(TYPEDSIGNATURES)
 
 Get a sorted set of keys from a tree that is possibly `missing`.
 """
-optional_tree_keys(::Missing) = SortedSet()
-optional_tree_keys(x) = SortedSet(keys(x))
+optional_tree_keys(::Missing) = SortedSet{Symbol}()
+optional_tree_keys(x) = SortedSet{Symbol}(keys(x))
 
 """
 $(TYPEDSIGNATURES)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,6 @@
 [deps]
+ConstraintTrees = "5515826b-29c3-47a5-8849-8513ac836620"
+
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Clarabel = "61c947e1-3e6d-4ee4-985a-eec8c727bd6e"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,20 @@
+[deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+Clarabel = "61c947e1-3e6d-4ee4-985a-eec8c727bd6e"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+SBML = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
+SCIP = "82193955-e24f-5292-bf16-6f2c5261a85f"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Accessors = "0.1"
+Clarabel = "0.11"
+GLPK = "1"
+JSON = "1"
+JuMP = "1"
+SBML = "1"
+SCIP = "0.12"


### PR DESCRIPTION
Some deps are old, preventing updates when using CTs in projects that use packages that depend on the latest version of e.g. DataStructures. 

New Julia format for test dep is to make a project.toml specifically for it in the test folder.